### PR TITLE
Add a load guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plug "ThePrimeagen/vim-apm"
 2. Set the keystroke callback to on
 
 ```
-set kscb
+set keystrokecallback
 ```
 
 3. Execute :VimApm. If you use Ctrl-w o to shut other buffers, you can bring

--- a/plugin/vim-apm.vim
+++ b/plugin/vim-apm.vim
@@ -1,3 +1,9 @@
+" TODO: Change to `has()` once it recognizes the new feature
+if !exists('&keystrokecallback')
+  echoerr "Feature 'keystrokecallback' not present in current vim installation"
+  finish
+endif
+
 fun! VimApm()
     lua package.loaded["vim-apm"] = nil
     lua package.loaded["vim-apm.buckets"] = nil

--- a/plugin/vim-apm.vim
+++ b/plugin/vim-apm.vim
@@ -1,10 +1,10 @@
-" TODO: Change to `has('keystrokecallback')` once it recognizes the new feature
-if !exists('&keystrokecallback')
-  echoerr "Feature 'keystrokecallback' not present in current vim installation"
-  finish
-endif
-
 fun! VimApm()
+    " TODO: Change to `has('keystrokecallback')` once it recognizes the new feature
+    if !exists('&keystrokecallback')
+      echoerr "Feature 'keystrokecallback' not present in current vim installation"
+      return
+    endif
+
     lua package.loaded["vim-apm"] = nil
     lua package.loaded["vim-apm.buckets"] = nil
     lua package.loaded["vim-apm.utils"] = nil

--- a/plugin/vim-apm.vim
+++ b/plugin/vim-apm.vim
@@ -1,4 +1,4 @@
-" TODO: Change to `has()` once it recognizes the new feature
+" TODO: Change to `has('keystrokecallback')` once it recognizes the new feature
 if !exists('&keystrokecallback')
   echoerr "Feature 'keystrokecallback' not present in current vim installation"
   finish


### PR DESCRIPTION
To prevent error vomit (try running on an unsupported version of neovim), add a load guard.

At the moment, the VimL is not very idiomatic: I use the `exists()` function to check for a setting. This is because `has()` does not recognize the new option. Once the [PR] is merged into master, the `has()` function should work.

Another additional layer of security would be to add another load guard to the lua files as well, so nothing can accidentally call them. It probably wouldn't happen, but you never know.

[PR]: https://github.com/neovim/neovim/pull/12536