### PR TITLE
apm-shutdown: Corrected keystroke callback function in shutdown.

### DIFF
--- a/lua/vim-apm/init.lua
+++ b/lua/vim-apm/init.lua
@@ -37,7 +37,7 @@ local function shutdown()
     timerIdx = timerIdx + 1
     bufh = 0
     win_id = 0
-    vim.remove_keystroke_callback(id)
+    vim.register_keystroke_callback(id)
     active = false
 end
 


### PR DESCRIPTION

Fixes #8 Error while shutting down Vim Apm

Fix: Replaced remove_keystroke_callback with register_keystroke_callback

https://neovim.io/doc/user/lua.html