### PR TITLE
Clearing keystroke callback on shutdown.

### DIFF
--- a/lua/vim-apm/init.lua
+++ b/lua/vim-apm/init.lua
@@ -37,7 +37,11 @@ local function shutdown()
     timerIdx = timerIdx + 1
     bufh = 0
     win_id = 0
-    vim.remove_keystroke_callback(id)
+    
+    -- get namespace id for "vim-apm" & clear keystroke callback function.
+    namespace_id = vim.fn.nvim_create_namespace("vim-apm")
+    vim.register_keystroke_callback(nil, namespace_id)
+    
     active = false
 end
 


### PR DESCRIPTION

Fixes #8 

**What caused it?**

1) `vim.remove_keystroke_callback(id)` --> Function throws error.
2) Also, keystroke callback function is not cleared on shutdown, printing "Error: Attempt to index global buckets (a nil value)" on each keystroke after shutdown.

**How to fix it?**

1) `nvim_create_namespace({name})`  --> If `name` matches an existing namespace, the associated id is returned.
We already have namespace `vim-apm` created in function `apm()`. We get its id.
2) `vim.register_keystroke_callback(nil, namespace_id)` --> setting keystroke callback function to `nil`.

**How was it tested?**

1) Manual testing. Starting the apm in one buffer and closing in another and multiple keypresses and keymaps after shutdown. Does not throw error and keymaps work as expected.

_I have no experience with lua or neovim api. I am a neovim enthusiast. Please do suggest if there is a better way to fix this.
PFB references for this solution._

**References:**

https://neovim.io/doc/user/api.html
![Screenshot 2020-09-17 at 12 20 14 AM](https://user-images.githubusercontent.com/44144208/93379561-9d2f2580-f87b-11ea-9d90-fc0449cc25f8.png)

https://neovim.io/doc/user/lua.html
![Screenshot 2020-09-17 at 12 21 36 AM](https://user-images.githubusercontent.com/44144208/93379720-d5ceff00-f87b-11ea-8cce-df7026fbedce.png)