### PR TITLE
Update incorrect statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ Warning, not ready for you to use yet.  please don't bothe me with issues
 ## Why Go?
 * [i did a poll](https://twitter.com/ThePrimeagen/status/1745166587781349888)
 * I want to use go templates and htmx and live that simple life style
+* I write Rust 🦀, btw
 * I want to use charm cli
 * I like go more than typescript
 * I like go more than javascript
 * I like go more than elixir (ok i haven't tried elixir)
-* I don't ackshually know how to program rust
-


### PR DESCRIPTION
This pull request includes a major change to the `README.md` file. The change updates the "Why Go?" section, adding a line to mention that the author writes in Rust (btw) and removing a line that stated the author doesn't know how to program in Rust. This suggests a shift in the author's programming language preference or skills.