### PR TITLE
Fix file reporter not trimming expired motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
 ## Vim APM
+This fork fixes two bugs that made the plugin look broken.
+
 This is still a very alpha application but should be a good time to use.
 
 ### Please file issues for
@@ -13,7 +15,19 @@ Here is my Lazy `config` function.
 ```lua
 local apm = require("vim-apm")
 
-apm:setup({})
+-- default opts
+local data_path = vim.fn.stdpath("data")
+local default_data_path = string.format("%s/vim-apm.json", data_path)
+apm:setup({
+    reporter = {
+        type = "file", -- or "memory", "network" reporter seems to be unfinished
+        uri = default_data_path,
+        report_interval = 1 * 60 * 1000, -- unused by file reporter
+        apm_repeat_count = 10, -- window size for diminishing returns, i.e. higher -> less diminishing returns on repeated motions
+        apm_period = 60 * 1000, -- in ms, actions per 1 minute, e.g. use 5*60*1000 for actions per 5 minute period
+        apm_report_period = 5 * 1000, -- in ms, updates the apm and stats with a period of this amount
+    }
+})
 vim.keymap.set("n", "<leader>apm", function() apm:toggle_monitor() end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ apm:setup({
     reporter = {
         type = "file", -- or "memory", "network" reporter seems to be unfinished
         uri = default_data_path,
-        report_interval = 1 * 60 * 1000, -- unused by file reporter
-        apm_repeat_count = 10, -- window size for diminishing returns, i.e. lower -> less diminishing returns on repeated motions
-        apm_period = 60 * 1000, -- in ms, actions per 1 minute, e.g. use 5*60*1000 for actions per 5 minute period
-        apm_report_period = 5 * 1000, -- in ms, updates the apm and stats with a period of this amount
+        interval_options = {
+            report_interval = 1 * 60 * 1000, -- unused by file reporter
+            apm_repeat_count = 10, -- window size for diminishing returns, i.e. lower -> less diminishing returns on repeated motions
+            apm_period = 60 * 1000, -- in ms, actions per 1 minute, e.g. use 5*60*1000 for actions per 5 minute period
+            apm_report_period = 5 * 1000, -- in ms, updates the apm and stats with a period of this amount
+        }
     }
 })
 vim.keymap.set("n", "<leader>apm", function() apm:toggle_monitor() end)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ apm:setup({
         type = "file", -- or "memory", "network" reporter seems to be unfinished
         uri = default_data_path,
         report_interval = 1 * 60 * 1000, -- unused by file reporter
-        apm_repeat_count = 10, -- window size for diminishing returns, i.e. higher -> less diminishing returns on repeated motions
+        apm_repeat_count = 10, -- window size for diminishing returns, i.e. lower -> less diminishing returns on repeated motions
         apm_period = 60 * 1000, -- in ms, actions per 1 minute, e.g. use 5*60*1000 for actions per 5 minute period
         apm_report_period = 5 * 1000, -- in ms, updates the apm and stats with a period of this amount
     }

--- a/lua/vim-apm/reporter/file-reporter.lua
+++ b/lua/vim-apm/reporter/file-reporter.lua
@@ -59,13 +59,14 @@ function FileReporter:enable()
         local ok2, res = pcall(vim.loop.fs_write, file, out_json)
         vim.loop.fs_close(file)
 
+        self.collector.calc:trim()
         APMBussin:emit(Events.APM_REPORT, self.collector.calc:apm())
         APMBussin:emit(Events.STATS, merged)
 
         if not ok2 then
             error("vim-apm: error writing to file: " .. res)
         end
-    end, self.opts.report_interval)
+    end, self.opts.apm_report_period)
 end
 
 function FileReporter:clear()


### PR DESCRIPTION
- Also fixes the file reporter firing APM_REPORT and STATS every minute (apm_period) instead of every five seconds (apm_report_period) by default
- Also adds the default config values and brief explanations of the opts to the readme. Let me know you'd prefer different wording anywhere